### PR TITLE
Install AWS CLI from alpine

### DIFF
--- a/.github/workflows/preprod-deployment.yml
+++ b/.github/workflows/preprod-deployment.yml
@@ -13,10 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Install build dependencies
-        run: |
-          apk add --no-cache alpine-sdk git python3 py3-pip bash
-          pip3 install --upgrade pip
-          pip3 install awscli
+        run: apk add --no-cache alpine-sdk git aws-cli bash
 
       - name: Check out repository code
         uses: actions/checkout@main

--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -13,10 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Install build dependencies
-        run: |
-          apk add --no-cache alpine-sdk git python3 py3-pip bash
-          pip3 install --upgrade pip
-          pip3 install awscli
+        run: apk add --no-cache alpine-sdk git aws-cli bash
 
       - name: Check out repository code
         uses: actions/checkout@main


### PR DESCRIPTION
The preprod and prod deployments fail due to a pip issue. Let's install AWS CLI from alpine packages.